### PR TITLE
chore(beads): configure sync branch for protected repo

### DIFF
--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -42,7 +42,7 @@
 # This setting persists across clones (unlike database config which is gitignored).
 # Can also use BEADS_SYNC_BRANCH env var for local override.
 # If not set, bd sync will require you to run 'bd config set sync.branch <branch>'.
-# sync-branch: "beads-sync"
+sync-branch: "beads-sync"
 
 # Multi-repo configuration (experimental - bd-307)
 # Allows hydrating from multiple repositories and routing writes to the correct JSONL


### PR DESCRIPTION
## Summary

Configures beads to use `beads-sync` branch for issue tracking metadata instead of direct commits to master.

This enables beads (`bd sync`) to work with branch protection rules by:
- Committing `.beads/issues.jsonl` to a separate `beads-sync` branch
- Using git worktrees for minimal disk overhead
- Avoiding conflicts with protected master branch

## Changes

- Uncommented `sync-branch: "beads-sync"` in `.beads/config.yaml`

## References

- [Beads Protected Branch Docs](https://github.com/steveyegge/beads/blob/main/docs/PROTECTED_BRANCHES.md)

🤖 Generated with [Claude Code](https://claude.ai/code)