### PR TITLE
docs: add worktree setup instructions for husky

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,12 @@ npx hardhat deploy:roffle --network sapphire --verify
 docker run -it -p8544-8548:8544-8548 ghcr.io/oasisprotocol/sapphire-localnet
 ```
 
+### Worktree Setup
+For each new git worktree, run:
+```bash
+npx husky install        # Enable pre-commit hooks
+```
+
 ## Architecture
 
 ### Monorepo Structure


### PR DESCRIPTION
## Summary
- Add documentation for running `npx husky install` in new git worktrees
- Required to enable pre-commit hooks in worktree environments

## Context
Git worktrees share the main `.git` directory but have separate working directories. Without running `husky install` in each worktree, pre-commit hooks fail to locate `lint-staged` correctly.

🤖 Generated with [Claude Code](https://claude.ai/code)