### PR TITLE
feat(security): add CSP header to nginx

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -21,6 +21,7 @@ FROM nginxinc/nginx-unprivileged:1.27-alpine
 
 # Copy nginx configuration first (better cache layering)
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY security-headers.conf /etc/nginx/security-headers.conf
 
 # Copy built assets
 COPY --from=builder /app/dist /usr/share/nginx/html

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -25,6 +25,7 @@ server {
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https://assets.oasis.io https://images.ctfassets.net https://raw.githubusercontent.com; connect-src 'self' https://sapphire.oasis.io wss://sapphire.oasis.io https://mainnet.base.org https://arb1.arbitrum.io https://eth.merkle.io https://*.walletconnect.com https://*.walletconnect.org wss://*.walletconnect.com wss://*.walletconnect.org; frame-src 'self' https://verify.walletconnect.com https://verify.walletconnect.org; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;" always;
         access_log off;
     }
 
@@ -37,6 +38,7 @@ server {
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https://assets.oasis.io https://images.ctfassets.net https://raw.githubusercontent.com; connect-src 'self' https://sapphire.oasis.io wss://sapphire.oasis.io https://mainnet.base.org https://arb1.arbitrum.io https://eth.merkle.io https://*.walletconnect.com https://*.walletconnect.org wss://*.walletconnect.com wss://*.walletconnect.org; frame-src 'self' https://verify.walletconnect.com https://verify.walletconnect.org; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;" always;
         access_log off;
     }
 
@@ -52,6 +54,7 @@ server {
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https://assets.oasis.io https://images.ctfassets.net https://raw.githubusercontent.com; connect-src 'self' https://sapphire.oasis.io wss://sapphire.oasis.io https://mainnet.base.org https://arb1.arbitrum.io https://eth.merkle.io https://*.walletconnect.com https://*.walletconnect.org wss://*.walletconnect.com wss://*.walletconnect.org; frame-src 'self' https://verify.walletconnect.com https://verify.walletconnect.org; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;" always;
     }
 
     # Handle 404 for missing files (return to SPA)

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -19,26 +19,16 @@ server {
     # Use ^~ to prevent regex locations from taking precedence
     location ^~ /assets/ {
         expires 1y;
-        add_header Cache-Control "public, no-transform, immutable";
-        add_header X-Frame-Options "SAMEORIGIN" always;
-        add_header X-Content-Type-Options "nosniff" always;
-        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
-        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https://assets.oasis.io https://images.ctfassets.net https://raw.githubusercontent.com; connect-src 'self' https://sapphire.oasis.io wss://sapphire.oasis.io https://mainnet.base.org https://arb1.arbitrum.io https://eth.merkle.io https://*.walletconnect.com https://*.walletconnect.org wss://*.walletconnect.com wss://*.walletconnect.org; frame-src 'self' https://verify.walletconnect.com https://verify.walletconnect.org; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;" always;
+        add_header Cache-Control "public, no-transform, immutable" always;
+        include /etc/nginx/security-headers.conf;
         access_log off;
     }
 
     # Static files (favicon, images in public/)
     location ~* \.(ico|png|jpg|jpeg|gif|svg|woff|woff2|ttf|eot)$ {
         expires 7d;
-        add_header Cache-Control "public, no-transform";
-        add_header X-Frame-Options "SAMEORIGIN" always;
-        add_header X-Content-Type-Options "nosniff" always;
-        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
-        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https://assets.oasis.io https://images.ctfassets.net https://raw.githubusercontent.com; connect-src 'self' https://sapphire.oasis.io wss://sapphire.oasis.io https://mainnet.base.org https://arb1.arbitrum.io https://eth.merkle.io https://*.walletconnect.com https://*.walletconnect.org wss://*.walletconnect.com wss://*.walletconnect.org; frame-src 'self' https://verify.walletconnect.com https://verify.walletconnect.org; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;" always;
+        add_header Cache-Control "public, no-transform" always;
+        include /etc/nginx/security-headers.conf;
         access_log off;
     }
 
@@ -46,15 +36,10 @@ server {
     # index.html must not be cached so deployments take effect immediately
     location / {
         try_files $uri $uri/ /index.html;
-        add_header Cache-Control "no-cache, no-store, must-revalidate";
-        add_header Pragma "no-cache";
-        add_header Expires "0";
-        add_header X-Frame-Options "SAMEORIGIN" always;
-        add_header X-Content-Type-Options "nosniff" always;
-        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
-        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https://assets.oasis.io https://images.ctfassets.net https://raw.githubusercontent.com; connect-src 'self' https://sapphire.oasis.io wss://sapphire.oasis.io https://mainnet.base.org https://arb1.arbitrum.io https://eth.merkle.io https://*.walletconnect.com https://*.walletconnect.org wss://*.walletconnect.com wss://*.walletconnect.org; frame-src 'self' https://verify.walletconnect.com https://verify.walletconnect.org; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;" always;
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+        add_header Pragma "no-cache" always;
+        add_header Expires "0" always;
+        include /etc/nginx/security-headers.conf;
     }
 
     # Handle 404 for missing files (return to SPA)

--- a/frontend/security-headers.conf
+++ b/frontend/security-headers.conf
@@ -1,0 +1,9 @@
+# Shared security headers (included in each location block)
+# NOTE: nginx's add_header is NOT inherited when a location block defines its own headers,
+# so this file must be included in every location block that uses add_header.
+add_header X-Frame-Options "SAMEORIGIN" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https://assets.oasis.io https://images.ctfassets.net https://raw.githubusercontent.com; connect-src 'self' https://sapphire.oasis.io wss://sapphire.oasis.io https://mainnet.base.org https://arb1.arbitrum.io https://eth.merkle.io https://*.walletconnect.com https://*.walletconnect.org wss://*.walletconnect.com wss://*.walletconnect.org; frame-src 'self' https://verify.walletconnect.com https://verify.walletconnect.org; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;" always;


### PR DESCRIPTION
## Summary

Adds a `Content-Security-Policy` header to all nginx location blocks, hardening the production Docker deployment against XSS and injection attacks while maintaining full Web3 wallet functionality.

Fixes #38

## CSP Policy Breakdown

| Directive | Value | Rationale |
|-----------|-------|-----------|
| `default-src` | `'self'` | Block all sources not explicitly allowed |
| `script-src` | `'self'` | Vite produces no inline scripts; all JS is bundled |
| `style-src` | `'self' 'unsafe-inline' fonts.googleapis.com` | RainbowKit injects runtime styles; Google Fonts CSS via @import |
| `font-src` | `'self' fonts.gstatic.com` | Google Fonts WOFF2 files + bundled Inter font |
| `img-src` | `'self' data: blob: assets.oasis.io images.ctfassets.net raw.githubusercontent.com` | Oasis logos, MetaMask icons, QR/jazzicon blobs |
| `connect-src` | `'self'` + RPC endpoints + WalletConnect | Chain RPCs (Sapphire, Base, Arbitrum, Ethereum) + WC relay |
| `frame-src` | `'self' verify.walletconnect.com/org` | WalletConnect session verification iframe |
| `object-src` | `'none'` | Block Flash/plugins entirely |
| `base-uri` | `'self'` | Prevent `<base>` tag injection |
| `form-action` | `'self'` | Prevent form hijacking |
| `upgrade-insecure-requests` | (present) | Force HTTPS on all resource loads |

## Verified RPC Endpoints (from viem 2.41.2 source)

- Sapphire: `https://sapphire.oasis.io` + `wss://sapphire.oasis.io`
- Base: `https://mainnet.base.org`
- Arbitrum: `https://arb1.arbitrum.io`
- Ethereum: `https://eth.merkle.io`

## Test Plan

- [x] Docker image builds successfully
- [x] CSP header present on HTML responses (`location /`)
- [x] CSP header present on hashed assets (`location ^~ /assets/`)
- [x] CSP header present on static files (`.ico`, `.png`, etc.)
- [ ] App loads without CSP violations in browser console
- [ ] MetaMask wallet connection works
- [ ] WalletConnect session pairing works
- [ ] Cross-chain bridge deposit flow completes

## Notes

- `'unsafe-inline'` in `style-src` is required by RainbowKit's runtime style injection — acceptable tradeoff since CSS-only exfiltration requires prior XSS
- WalletConnect domains use wildcards (`*.walletconnect.com`) since WC frequently adds subdomains
- No `worker-src` needed (no Web Workers in production bundle)