### PR TITLE
fix(ui): remove redundant progress box, show step in button

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -353,7 +353,6 @@ export function App() {
   // Button state
   const getButtonText = () => {
     if (!isValidConnection) return 'Connect Wallet'
-    if (paymaster.isLoading) return 'Processing...'
     if (!amount || parsedAmount === 0n) return 'Enter amount'
     if (depositLimits.isLoading) return 'Checking limits...'
     if (depositLimits.isError) return 'Unable to verify limits'
@@ -417,7 +416,7 @@ export function App() {
               maxValue={effectiveMax}
               balance={sourceBalance.data?.value}
               balanceLabel="Balance"
-              disabled={!!paymaster.currentStep || !isValidConnection}
+              disabled={paymaster.isLoading || !isValidConnection}
               insufficientBalance={hasInputError}
               placeholder="0.00"
               trailing={
@@ -428,7 +427,7 @@ export function App() {
                     icon: selectedToken?.icon ?? getTokenIcon('USDC'),
                   }}
                   onClick={() => setChainTokenModalOpen(true)}
-                  disabled={!!paymaster.currentStep}
+                  disabled={paymaster.isLoading}
                 />
               }
             />
@@ -463,21 +462,6 @@ export function App() {
               variant="static"
             />
 
-            {/* Progress Steps */}
-            {paymaster.currentStep && (
-              <div className="mt-4 p-4 rounded-xl bg-black/20 border border-white/10">
-                <div className="flex items-center gap-3">
-                  <LucideLoader className="size-5 animate-spin text-white/70" />
-                  <span className="text-sm text-white">{paymaster.currentStep.label}</span>
-                </div>
-                {paymaster.currentStep.expectedTimeInSeconds && (
-                  <p className="text-xs text-white/50 mt-2 ml-8">
-                    This may take ~{paymaster.currentStep.expectedTimeInSeconds}s
-                  </p>
-                )}
-              </div>
-            )}
-
             {/* Errors are shown via toast notifications */}
 
             {/* Pending Transaction Recovery */}
@@ -506,7 +490,14 @@ export function App() {
               )}
             >
               {paymaster.isLoading ? (
-                <LucideLoader className="size-5 animate-spin mx-auto" />
+                <span className="flex items-center justify-center gap-2">
+                  <LucideLoader className="size-5 animate-spin" />
+                  <span>
+                    {paymaster.currentStep?.label ?? 'Processing...'}
+                    {paymaster.currentStep?.expectedTimeInSeconds &&
+                      ` (~${paymaster.currentStep.expectedTimeInSeconds}s)`}
+                  </span>
+                </span>
               ) : (
                 getButtonText()
               )}
@@ -559,7 +550,7 @@ export function App() {
         selectedChainId={selectedSourceChainId}
         selectedTokenKey={selectedTokenKey}
         onSelect={handleChainTokenSelect}
-        disabled={!!paymaster.currentStep}
+        disabled={paymaster.isLoading}
       />
     </div>
   )


### PR DESCRIPTION
## Summary

- Remove separate progress indicator section that showed duplicate spinner during bridge operations
- Integrate step label and expected time directly into the bridge button
- Fix input locking bug: change `disabled` condition from `!!currentStep` to `isLoading`
- Remove dead code branch in `getButtonText()`

## Changes

| File | Change |
|------|--------|
| `frontend/src/App.tsx` | Remove progress box (lines 466-479), update button content, fix disabled conditions |

## Root Cause

The bugs shared a common root cause: using `currentStep` as a UI gate instead of `isLoading`:
- `currentStep` is designed to persist after operations (for recovery/debugging)
- `isLoading` is the true "operation in progress" flag, cleared in `finally` blocks
- The fix changes the UI contract to: "show progress while loading" vs "show progress while step exists"

## Acceptance Criteria

- [x] Given a bridge is in progress, then the step label shows inside the bridge button next to the spinner — no separate progress box
- [x] Given the user rejects a wallet transaction, then the button returns to its default state and no stale progress is shown
- [x] Given any step is active, then there is only one spinner visible on screen (in the button)

## Test Plan

- [ ] Start a bridge operation → verify single spinner in button with step label
- [ ] Reject wallet transaction (e.g., MetaMask) → verify button returns to default, no stale progress
- [ ] Verify inputs are re-enabled after rejection (was a secondary bug fixed by this PR)

Fixes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)